### PR TITLE
Fixed absolute path cache miss in workflow-testing.

### DIFF
--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -12,13 +12,19 @@ pluginManagement {
 }
 
 plugins {
-  id("com.gradle.enterprise") version "3.13.4"
+  id("com.gradle.enterprise") version "3.15"
+  id("com.gradle.common-custom-user-data-gradle-plugin") version "1.11.2"
 }
 
 gradleEnterprise {
+  server = "http://ec2-44-197-116-189.compute-1.amazonaws.com"
+  allowUntrustedServer = true // unless a trusted certificate is already
   buildScan {
-    termsOfServiceUrl = "https://gradle.com/terms-of-service"
-    termsOfServiceAgree = "yes"
+    publishAlways()
+    capture {
+      isTaskInputFiles = true
+    }
+    isUploadInBackground = System.getenv("CI") == null // adjust to your CI provider
   }
 }
 

--- a/workflow-testing/build.gradle.kts
+++ b/workflow-testing/build.gradle.kts
@@ -15,8 +15,7 @@ tasks.withType<org.jetbrains.kotlin.gradle.tasks.KotlinCompile> {
     val friendModule = project(":workflow-core")
 
     // Pointing to jar instead of classes dir since :workflow-core is a multiplatform project.
-    val jarPath = friendModule.configurations["jvmRuntimeElements"].artifacts.first().file.path
-    freeCompilerArgs += "-Xfriend-paths=$jarPath"
+    friendPaths.from(friendModule.configurations["jvmRuntimeElements"].artifacts.first().file)
   }
 }
 

--- a/workflow-ui/core-common/src/main/java/com/squareup/workflow1/ui/Compatible.kt
+++ b/workflow-ui/core-common/src/main/java/com/squareup/workflow1/ui/Compatible.kt
@@ -36,14 +36,19 @@ public interface Compatible {
 
   public companion object {
     /**
-     * Calculates a suitable [Compatible.compatibilityKey] for a given [value] and [name].
+     * Calculates a suitable [Compatible.compatibilityKey] for a given [value], incorporating
+     * [name] if that is not blank. Includes the [compatibilityKey] for [value] if it
+     * implements [Compatible], to support recursion from wrapping.
+     *
+     * Style note: [name] is given more prominence than the key generate
      */
     public fun keyFor(
       value: Any,
       name: String = ""
     ): String {
-      return ((value as? Compatible)?.compatibilityKey ?: value::class.java.name) +
-        if (name.isEmpty()) "" else "+$name"
+      val key = (value as? Compatible)?.compatibilityKey ?: value::class.java.name
+
+      return name.takeIf { it.isNotEmpty() }?.let { "$name($key)" } ?: key
     }
   }
 }

--- a/workflow-ui/core-common/src/main/java/com/squareup/workflow1/ui/Named.kt
+++ b/workflow-ui/core-common/src/main/java/com/squareup/workflow1/ui/Named.kt
@@ -15,7 +15,7 @@ public data class Named<W : Any>(
     require(name.isNotBlank()) { "name must not be blank." }
   }
 
-  override val compatibilityKey: String = Compatible.keyFor(wrapped, "Named($name)")
+  override val compatibilityKey: String = Compatible.keyFor(wrapped, "Named:$name")
 
   override fun toString(): String {
     return "${super.toString()}: $compatibilityKey"

--- a/workflow-ui/core-common/src/main/java/com/squareup/workflow1/ui/NamedScreen.kt
+++ b/workflow-ui/core-common/src/main/java/com/squareup/workflow1/ui/NamedScreen.kt
@@ -16,7 +16,7 @@ public data class NamedScreen<C : Screen>(
     require(name.isNotBlank()) { "name must not be blank." }
   }
 
-  override val compatibilityKey: String = Compatible.keyFor(content, "NamedScreen($name)")
+  override val compatibilityKey: String = Compatible.keyFor(content, "NamedScreen:$name")
 
   @Deprecated("Use content", ReplaceWith("content"))
   public val wrapped: C = content

--- a/workflow-ui/core-common/src/test/java/com/squareup/workflow1/ui/NamedScreenTest.kt
+++ b/workflow-ui/core-common/src/test/java/com/squareup/workflow1/ui/NamedScreenTest.kt
@@ -57,7 +57,7 @@ internal class NamedScreenTest {
 
   @Test fun `recursive keys are legible`() {
     assertThat(NamedScreen(NamedScreen(Hey, "one"), "ho").compatibilityKey)
-      .isEqualTo("com.squareup.workflow1.ui.NamedScreenTest\$Hey+NamedScreen(one)+NamedScreen(ho)")
+      .isEqualTo("NamedScreen:ho(NamedScreen:one(com.squareup.workflow1.ui.NamedScreenTest\$Hey))")
   }
 
   private class Foo(override val compatibilityKey: String) : Compatible, Screen

--- a/workflow-ui/core-common/src/test/java/com/squareup/workflow1/ui/NamedTest.kt
+++ b/workflow-ui/core-common/src/test/java/com/squareup/workflow1/ui/NamedTest.kt
@@ -5,7 +5,7 @@ import org.junit.Test
 
 // If you try to replace isTrue() with isTrue compilation fails.
 @OptIn(WorkflowUiExperimentalApi::class)
-@Suppress("UsePropertyAccessSyntax", "DEPRECATION")
+@Suppress("DEPRECATION")
 internal class NamedTest {
   object Whut
   object Hey
@@ -58,7 +58,7 @@ internal class NamedTest {
 
   @Test fun `recursive keys are legible`() {
     assertThat(Named(Named(Hey, "one"), "ho").compatibilityKey)
-      .isEqualTo("com.squareup.workflow1.ui.NamedTest\$Hey+Named(one)+Named(ho)")
+      .isEqualTo("Named:ho(Named:one(com.squareup.workflow1.ui.NamedTest\$Hey))")
   }
 
   private class Foo(override val compatibilityKey: String) : Compatible


### PR DESCRIPTION
Fixed absolute path cache miss in workflow-testing.
- Provided friendPaths using built-in property that is configured with relative path sensitivity.

[Task Build Comparison before fix](https://ec2-44-197-116-189.compute-1.amazonaws.com/c/a6w6sd7knpcws/q2a2mmvi4t2k2/task-inputs?cacheability=cacheable,overlapping-outputs,validation-failure)

[Task Build Comparison after fix](https://ec2-44-197-116-189.compute-1.amazonaws.com/c/ualvactfgomys/3z4wl7fctqeio/task-inputs?cacheability=cacheable,overlapping-outputs,validation-failure)